### PR TITLE
Type check ci test

### DIFF
--- a/.github/workflows/validate-types.yml
+++ b/.github/workflows/validate-types.yml
@@ -1,0 +1,26 @@
+name: Validate Types
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run type tests (explicit src tsconfig)
+        run: npx tsc --noEmit -p src/tsconfig.json

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,57 @@
+export class Terminal {}
+export class Process {}
+
+export class BinaryFile {
+	write(data: ArrayBuffer): Promise<number>;
+
+	read(length: number): Promise<ArrayBuffer>;
+  
+	getSize(): Promise<number>;
+
+   close(): Promise<void>;
+}
+
+export class TextFile {
+	write(data: string): Promise<number>;
+
+	read(length: number): Promise<string>;
+
+	getSize(): Promise<number>;
+
+	close(): Promise<void>;
+}
+
+
+export class BrowserPod {
+	static boot(opts: {
+		nodeVersion?: string;
+		apiKey: string;
+  	}): Promise<BrowserPod>;
+
+	run(
+		executable: string,
+		args: Array<string>,
+		opts: {
+				terminal: Terminal,
+				env?: Array<string>;
+				cwd?: string,
+				echo?: boolean
+			}
+  	): Promise<Process>;
+
+   onPortal(cb: ( args: { url: string, port: number }) => void): void;
+
+	createDirectory(
+		path: string,
+		opts?: { recursive?: boolean }
+  	): Promise<void>;
+
+	createFile(path: string, mode: string): Promise<BinaryFile | TextFile>;
+
+	openFile(path: string, mode: string): Promise<BinaryFile | TextFile>;
+
+	createDefaultTerminal(
+		consoleDiv: HTMLElement,
+	): Promise<Terminal>;
+}
+

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+	"lib": ["ES2020", "DOM"]
+  },
+  "include": ["index.d.ts"]
+}


### PR DESCRIPTION
Added `validate-types.yml ` and `tsconfig.json` to run TypeScript validation on pushes and PR's to main


***NOTE***: Make sure to merge type population first since this branched is based on that one to avoid duplicate commits (hope im correct there)