### PR TITLE
Change onOutput parameter type to ArrayBuffer

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -60,7 +60,7 @@ export class BrowserPod {
 	createCustomTerminal(opts: {
 		cols?: number;
 		rows?: number;
-		onOutput: (buffer: Uint8Array | ArrayBuffer, vt?: unknown) => void;
+		onOutput: (buffer: ArrayBuffer, vt?: unknown) => void;
 	}): Promise<Terminal>;
 }
 


### PR DESCRIPTION
source of some documentation confusion.  onOutput only returns an ArrayBuffer.

Might have been types differently due to the terminal's internal write method returning Uint8Array. 