### PR TITLE
fix: correct 'agengts' keyword typo to 'agents'

### DIFF
--- a/packages/browserpod-lt/package.json
+++ b/packages/browserpod-lt/package.json
@@ -20,7 +20,7 @@
     "node",
     "virtualization",
     "sandbox",
-    "agengts",
+    "agents",
     "wasm",
     "leaningtech"
   ],

--- a/packages/browserpod/package.json
+++ b/packages/browserpod/package.json
@@ -20,7 +20,7 @@
     "node",
     "virtualization",
     "sandbox",
-    "agengts",
+    "agents",
     "wasm",
     "leaningtech"
   ],


### PR DESCRIPTION
Both npm package manifests (`browserpod`, `@leaningtech/browserpod`) list `agengts` as a keyword. Fixing to `agents` so the packages surface under the right searches on npmjs.com. Also hinted at in #16.