### PR TITLE
feat: agent-bay showcase — gated agent missions in a pod

### DIFF
--- a/examples/showcase/agent-bay/.env.example
+++ b/examples/showcase/agent-bay/.env.example
@@ -1,0 +1,3 @@
+# BrowserPod API key. Copy this file to `.env` and fill it in; without it the pod
+# refuses to boot. Get one at https://browserpod.io
+VITE_BP_APIKEY=

--- a/examples/showcase/agent-bay/README.md
+++ b/examples/showcase/agent-bay/README.md
@@ -1,0 +1,50 @@
+# Agent Bay
+
+A mission-driven agent loop inside a [BrowserPod](https://browserpod.io) sandbox. Clone a repo, run a batch of steps against it, and write a verdict log — every mutation goes through a small gate that only allows writes inside the lanes the mission declares.
+
+This is a demo of the "AI Agents environment" use case from the BrowserPod README: untrusted code running loose, isolated from the OS, but with a deterministic capability boundary instead of a free-for-all shell.
+
+## Running it
+
+```sh
+npm install
+cp .env.example .env   # then set VITE_BP_APIKEY
+npm run dev
+```
+
+BrowserPod needs `SharedArrayBuffer`, so the page must be cross-origin isolated. `vite.config.ts` sets the COOP/COEP headers for dev and preview; `static/_headers` sets them for the static build.
+
+## How it works
+
+- **mission.json** — the task contract. Picked from the editor, or paste a mission file from anywhere:
+
+  ```json
+  {
+    "name": "checkout + install + test",
+    "clone": { "url": "https://github.com/leaningtech/browserpod-meta", "ref": "main" },
+    "locks": ["agent-bay/**"],
+    "steps": [
+      { "label": "inspect", "run": "ls -la", "store": "listing" },
+      { "label": "install", "run": "npm install --no-audit --no-fund" },
+      { "label": "test", "run": "npm test || echo \"(no test script)\"" }
+    ],
+    "verdictPath": "agent-bay/verdicts.md"
+  }
+  ```
+
+- **clone** — shallow `git clone` of the target repo, into a fresh `/repo`.
+- **locks** — the lanes the agent may *write* to, as path prefixes relative to the repo root. Everything else is write-blocked. `.git` / `.jj` are always refused.
+- **steps** — bash lines, run in order through `/bin/bash -lc` in `/repo`. A step that fails stops the mission. `@step:N@` in a later step expands to the stdout of step N (when that step set `"store"`).
+- **verdicts** — on success, the mission writes `verdicts.md` (append-only style) into the sandbox at `verdictPath`.
+
+## The gate
+
+`src/lib/mission/gate.ts` embeds a small gate script that is installed into the sandbox and runs **before every mutation**: `node gate.js write <json>` refuses writes outside the locked lanes, `mkdir` refuses anything outside the lanes (except the gate's own dir), and `exec` refuses shell lines that try to reach outside the repo (`rm -rf /`, `..` escapes, and so on). The gate is a deterministic allowlist — the agent's capabilities are a bounded verb surface, denied by construction rather than by review.
+
+The same design principle is used in production at [ATLAS](https://github.com/Zero2oneZ/ATLAS) as its token gate: model output is untrusted input, and proposed actions only execute behind an explicit, cheap allowlist check.
+
+## Notes
+
+- The pod persists per tab (`?pod=<key>` for a second window, like bramble).
+- Every mission replays cleanly: the runner `rm -rf`s `/repo` first.
+- Only public repos work today; the pod's git is unauthenticated.

--- a/examples/showcase/agent-bay/package.json
+++ b/examples/showcase/agent-bay/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "agent-bay",
+	"description": "Run an agentic batch job against a cloned repository inside a BrowserPod sandbox: a mission file drives clones, scripts and verdicts, every mutation goes through a gate.",
+	"private": true,
+	"version": "0.0.1",
+	"type": "module",
+	"scripts": {
+		"dev": "vite dev",
+		"build": "vite build",
+		"preview": "vite preview",
+		"prepare": "svelte-kit sync || echo ''",
+		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
+	},
+	"devDependencies": {
+		"@sveltejs/adapter-static": "^3.0.10",
+		"@sveltejs/kit": "^2.50.2",
+		"@sveltejs/vite-plugin-svelte": "^6.2.4",
+		"@tailwindcss/vite": "^4.1.18",
+		"@types/node": "^24",
+		"svelte": "^5.51.0",
+		"svelte-check": "^4.4.2",
+		"tailwindcss": "^4.1.18",
+		"typescript": "^5.9.3",
+		"vite": "^7.3.1"
+	},
+	"dependencies": {
+		"@leaningtech/browserpod": "^3.0.1"
+	}
+}

--- a/examples/showcase/agent-bay/src/app.d.ts
+++ b/examples/showcase/agent-bay/src/app.d.ts
@@ -1,0 +1,8 @@
+/// <reference types="@sveltejs/kit" />
+
+// See https://svelte.dev/docs/kit/types#app-d-ts
+declare global {
+	namespace App {}
+}
+
+export {};

--- a/examples/showcase/agent-bay/src/app.html
+++ b/examples/showcase/agent-bay/src/app.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1" />
+		<meta
+			name="description"
+			content="Run an agentic batch job against a cloned repository inside a BrowserPod sandbox."
+		/>
+		<title>Agent Bay — gated agent jobs in the browser</title>
+		%sveltekit.head%
+	</head>
+	<body data-sveltekit-preload-data="hover">
+		<div style="display: contents">%sveltekit.body%</div>
+	</body>
+</html>

--- a/examples/showcase/agent-bay/src/lib/mission/examples.ts
+++ b/examples/showcase/agent-bay/src/lib/mission/examples.ts
@@ -1,0 +1,34 @@
+/**
+ * Example missions for Agent Bay. Copy one into the editor, or paste a URL
+ * to a mission file hosted anywhere.
+ */
+import type { Mission } from './types';
+
+export const EXAMPLE_MISSIONS: Mission[] = [
+	{
+		name: 'checkout + install + test',
+		description: 'Clone a small Node repo, install, run tests, record the verdict.',
+		clone: { url: 'https://github.com/leaningtech/browserpod-meta', ref: 'main' },
+		locks: ['agent-bay/**'],
+		steps: [
+			{ label: 'inspect', run: 'ls -la', store: 'listing' },
+			{ label: 'install', run: 'npm install --no-audit --no-fund' },
+			{ label: 'test', run: 'npm test || echo "(no test script)"' },
+			{ label: 'summary', run: 'echo "Mission complete. Worktree: @step:1@"' }
+		],
+		verdictPath: 'agent-bay/verdicts.md',
+		accent: '7dd3fc'
+	},
+	{
+		name: 'webhook smoke',
+		description: 'Boot the general-hook demo and hit its mock route through a portal.',
+		clone: { url: 'https://github.com/leaningtech/browserpod-meta.git', ref: 'main' },
+		locks: ['**'],
+		steps: [
+			{ label: 'install', run: 'npm ci --no-audit' },
+			{ label: 'serve', run: 'npx vite --port 4173 --host' },
+			{ label: 'probe', run: 'sleep 1; curl -sS -o /dev/null -w "%{http_code}" http://127.0.0.1:4173/ || echo "no response"' }
+		],
+		verdictPath: 'smoke/verdicts.md'
+	}
+];

--- a/examples/showcase/agent-bay/src/lib/mission/gate.ts
+++ b/examples/showcase/agent-bay/src/lib/mission/gate.ts
@@ -1,0 +1,104 @@
+/**
+ * The gate: a small, deterministic allowlist check that runs BEFORE every
+ * write and every exec in the sandbox. The pod's node runs scripts from a
+ * filesystem, so the gate itself ships inside the pod and is invoked with
+ * `node /agent-bay/gate.js <verb> <payload-json>` — each mutation either
+ * passes (exit 0) or the agent sees a blocking error and the mutation is
+ * never applied.
+ *
+ * This is the same shape as ATLAS's token_gate: the agent's capabilities are
+ * a bounded verb surface, and anything outside it is denied by construction
+ * rather than by review.
+ */
+
+const GATE = String.raw`// agent-bay gate — installed into the sandbox, runs on every mutation.
+import fs from 'node:fs';
+
+const [verb, arg] = process.argv.slice(2);
+
+function die(msg) {
+  console.error('[gate] ' + msg);
+  process.exit(1);
+}
+
+// The agent may WRITE only inside these prefixes (relative to repo root).
+// Anything else — node_modules, .git, /, .. — is refused. Reads are not
+// gated, so the agent can inspect everything it needs to write well.
+const locks = JSON.parse(process.env.AGENT_LOCKS || '[]');
+// 'src/**' means 'anything under src/'; strip the trailing glob and compare
+// as a plain prefix. Bare 'src' behaves the same.
+const lockPrefixes = locks.map((l) => String(l).replace(/\/\*\*$/, ''));
+const isLocked = (p) =>
+  lockPrefixes.some((l) => p === l || p.startsWith(l.endsWith('/') ? l : l + '/'));
+
+function normalize(p) {
+  const parts = [];
+  for (const seg of String(p).replace(/\\/g, '/').split('/')) {
+    if (!seg || seg === '.') continue;
+    if (seg === '..') die('path escapes the repo: ' + p);
+    parts.push(seg);
+  }
+  const rel = parts.join('/');
+  if (!rel) die('empty path');
+  return rel;
+}
+
+let payload = [];
+try {
+  payload = JSON.parse(arg || '[]');
+} catch {
+  die('bad payload');
+}
+
+switch (verb) {
+  case 'write': {
+    const [file] = payload;
+    const rel = normalize(file);
+    if (rel.startsWith('.git/') || rel.startsWith('.jj/')) die('writes inside metadata are refused');
+    if (!isLocked(rel)) die('write outside the locked lanes: ' + rel);
+    break;
+  }
+  case 'mkdir': {
+    const [dir] = payload;
+    if (dir.startsWith('/agent-bay/')) break;
+    if (dir.startsWith('.git/') || dir.startsWith('.jj/')) die('mkdir inside .git/.jj is refused');
+    const rel = normalize(dir);
+    if (!isLocked(rel)) die('mkdir outside the locked lanes: ' + rel);
+    break;
+  }
+  case 'exec': {
+    const [cmd] = payload;
+    if (/;\s*(rm|mv|cp|chmod|chown)\s+-[a-z]+[^;]*--\s*(\/|\.\.)/.test(cmd)) die('refusing dangerous shell line');
+    // Shell redirections are the other way a step could write; check every
+    // '>' or '>>' target against the locked lanes too.
+    for (const m of String(cmd).matchAll(/(?:^|;|\|\||&&)\s*[^>|;&]*?>>?\s+(\S+)/g)) {
+      const target = m[1].replace(/^['"]|['"]$/g, '');
+      if (target.startsWith('/') || target.includes('..')) die('redirect outside the repo: ' + target);
+      if (!isLocked(normalize(target))) die('redirect outside the locked lanes: ' + target);
+    }
+    break;
+  }
+  default:
+    die('unknown verb ' + verb);
+}
+`;
+
+export function gateScript(): string {
+	return GATE;
+}
+
+/**
+ * Ask the gate inside the pod whether a mutation is allowed. Cheap and
+ * synchronous in the sandbox: `node gate.js <verb> <json>`.
+ */
+export async function gateAll(
+	pod: import('@leaningtech/browserpod').BrowserPod,
+	verb: 'write' | 'mkdir' | 'exec',
+	payload: unknown[]
+): Promise<boolean> {
+	const { run } = await import('$lib/pod/run');
+	const result = await run(pod, 'node', ['/agent-bay/gate.js', verb, JSON.stringify(payload)], {
+		cwd: '/agent-bay'
+	});
+	return result.exitCode === 0;
+}

--- a/examples/showcase/agent-bay/src/lib/mission/runner.ts
+++ b/examples/showcase/agent-bay/src/lib/mission/runner.ts
@@ -1,0 +1,149 @@
+/**
+ * The runner: one mission = one pod session. It clones the repo, installs
+ * the gate, runs each step through it in order, and writes a verdict log.
+ * The UI calls `runMission` once; the return value is the full report.
+ */
+import type { BrowserPod } from '@leaningtech/browserpod';
+import type { Mission, Step } from './types';
+import { gateAll, gateScript } from './gate';
+import { run, runScript, failed, failureMessage, stripAnsi } from '$lib/pod/run';
+import { writePodFile, makeDirectory } from '$lib/pod/fs';
+
+export type StepStatus = 'ok' | 'failed' | 'blocked';
+
+export interface StepResult {
+	label: string;
+	run: string;
+	status: StepStatus;
+	exitCode: number;
+	output: string;
+	blockedReason?: string;
+}
+
+export interface MissionReport {
+	missionName: string;
+	repoUrl: string;
+	steps: StepResult[];
+	cloneFailed?: string;
+	finishedAt: string;
+	verdictPath: string;
+}
+
+function now(): string {
+	return new Date().toISOString();
+}
+
+/** Install the gate script into the sandbox (once per pod). */
+async function installGate(pod: BrowserPod): Promise<void> {
+	await makeDirectory(pod, '/agent-bay');
+	await writePodFile(pod, '/agent-bay/gate.js', gateScript());
+}
+
+/** Clones `mission.clone` into `/repo` (fresh dir each run so missions replay). */
+async function cloneRepo(pod: BrowserPod, mission: Mission) {
+	await run(pod, 'rm', ['-rf', '--', '/repo']);
+	const args = ['clone', '--depth', '1', '--no-single-branch'];
+	if (mission.clone.ref) args.push('--branch', mission.clone.ref);
+	args.push(mission.clone.url, '/repo');
+	return await run(pod, 'git', args);
+}
+
+/** Expands `@step:N@` placeholders in a command with earlier stored outputs. */
+function expandPlaceholders(cmd: string, stores: Map<number, string>): string {
+	return cmd.replace(/@step:(\d+)@/g, (_m, n) => stores.get(Number(n)) ?? '');
+}
+
+export async function runMission(pod: BrowserPod, mission: Mission): Promise<MissionReport> {
+	await installGate(pod);
+
+	const report: MissionReport = {
+		missionName: mission.name,
+		repoUrl: mission.clone.url,
+		steps: [],
+		finishedAt: now(),
+		verdictPath: mission.verdictPath ?? 'agent-bay/verdicts.md'
+	};
+
+	const cloneResult = await cloneRepo(pod, mission);
+	if (failed(cloneResult)) {
+		report.cloneFailed = failureMessage(cloneResult, 'clone error');
+		report.finishedAt = now();
+		return report;
+	}
+
+	// The gate reads the lock list from the pod filesystem.
+	await writePodFile(
+		pod,
+		'/agent-bay/locks.json',
+		JSON.stringify(mission.locks ?? [], null, 2)
+	);
+	const env = [`AGENT_LOCKS=${JSON.stringify(mission.locks ?? [])}`, `AGENT_ROOT=/repo`];
+
+	const stores = new Map<number, string>();
+
+	for (let i = 0; i < (mission.steps ?? []).length; i++) {
+		const step: Step = mission.steps[i];
+		const label = step.label ?? `step ${i + 1}`;
+		const cmd = expandPlaceholders(step.run, stores);
+
+		// Ask the gate first; it refuses dangerous shell lines and writes
+		// outside the locked lanes.
+		const allowed = await gateAll(pod, 'exec', [cmd]);
+		if (!allowed) {
+			report.steps.push({
+				label,
+				run: step.run,
+				status: 'blocked',
+				exitCode: -1,
+				output: '',
+				blockedReason: 'the gate refused this shell line'
+			});
+			continue;
+		}
+
+		const result = await runScript(pod, cmd, { cwd: '/repo', env });
+		const status: StepStatus = failed(result) ? 'failed' : 'ok';
+		if (step.store && status === 'ok') {
+			stores.set(i, stripAnsi(result.output).trim());
+		}
+
+		report.steps.push({
+			label,
+			run: step.run,
+			status,
+			exitCode: result.exitCode,
+			output: result.output
+		});
+
+		if (status === 'failed') break;
+	}
+
+	// Verdict log — append-only inside the pod, on the repo's locked lanes.
+	const verdictPath = report.verdictPath;
+	const verdict = [
+		`# Mission: ${mission.name}`,
+		``,
+		`- repo: ${mission.clone.url}`,
+		`- finished: ${now()}`,
+		`- failed: ${report.steps.some((s) => s.status === 'failed') ? 'yes' : 'no'}`,
+		``,
+		...(report.steps.flatMap((s) => [
+			`## ${s.label} — ${s.status}`,
+			``,
+			'```bash',
+			s.run,
+			'```',
+			``,
+			s.blockedReason ? `_${s.blockedReason}_` : s.output.trim() ? s.output.trim() : '_no output_',
+			``
+		])),
+		`---`
+	].join('\n');
+
+	const dir = verdictPath.includes('/') ? verdictPath.slice(0, verdictPath.lastIndexOf('/')) : '.';
+	await makeDirectory(pod, `/repo/${dir}`);
+	await writePodFile(pod, `/repo/${verdictPath.startsWith('/') ? verdictPath : `/repo/${verdictPath}`}`, verdict);
+
+	report.finishedAt = now();
+	return report;
+}

--- a/examples/showcase/agent-bay/src/lib/mission/types.ts
+++ b/examples/showcase/agent-bay/src/lib/mission/types.ts
@@ -1,0 +1,63 @@
+/**
+ * Mission types: the contract between a mission file and the runner.
+ *
+ * A mission is a JSON file (checked into the worktree, or fetched from a URL)
+ * that tells the bay what to do with a repository:
+ *
+ *   - `clone`   the repo to work on (git, shallow)
+ *   - `locks`   lanes the job may touch (readme, src/, docs/) — paths are
+ *               matched with `pathToRegexp`-style globs; `**` matches any
+ *               depth. Anything not in `locks` is off-limits to writes.
+ *   - `steps`   bash lines run through the gate, in order
+ *   - `signals` a way to pass data between the step's stdout and a later
+ *               step's stdin, using `@step:N@` placeholders
+ *
+ * Every `steps` entry runs inside the sandbox with `cwd` = the clone root.
+ * The gate refuses any step whose command contains a write to a path
+ * outside `locks`, and refuses steps that mutate git metadata
+ * (`.git` / `.jj` are always locked out).
+ */
+
+export interface Lock {
+	/** Path prefix, relative to the repo root. `**` matches any depth. */
+	prefix: string;
+	/** Optional comment shown in the UI, e.g. "src/ — source files". */
+	note?: string;
+}
+
+export interface Step {
+	/** A bash line. Runs through `/bin/bash -lc` with the pod env. */
+	run: string;
+	/** Human-readable label for the UI (e.g. "install deps"). */
+	label?: string;
+	/** If set, the step's stdout is captured and stored under this key. */
+	store?: string;
+}
+
+export interface CloneSpec {
+	/** The URL to clone. */
+	url: string;
+	/** Optional ref (branch/tag/commit) to check out. */
+	ref?: string;
+}
+
+export interface Mission {
+	/** Human-readable name, shown in the header. */
+	name: string;
+	/** One-line description. */
+	description?: string;
+	/** Repo to clone into the sandbox. */
+	clone: CloneSpec;
+	/**
+	 * Lanes the agent may WRITE to. Paths are relative to the repo root,
+	 * `**` matches any depth. Anything else is write-blocked by the gate.
+	 * Example: ["src/**", "docs/**"]
+	 */
+	locks: string[];
+	/** Steps executed in order, each through the gate. */
+	steps: Step[];
+	/** Where to write the verdict log. Default: `agent-bay/verdicts.md`. */
+	verdictPath?: string;
+	/** Optional mission display color (hex, no #). */
+	accent?: string;
+}

--- a/examples/showcase/agent-bay/src/lib/pod/boot.ts
+++ b/examples/showcase/agent-bay/src/lib/pod/boot.ts
@@ -1,0 +1,44 @@
+/**
+ * Pod lifecycle, following bramble's boot.ts shape.
+ */
+import type { BrowserPod } from '@leaningtech/browserpod';
+
+export const POD_STORAGE_KEY = 'agent-bay';
+
+export class PodBootError extends Error {}
+
+/** Boots or reopens the persistent pod. Browser only, never call during SSR. */
+export async function bootPod(storageKey = POD_STORAGE_KEY): Promise<BrowserPod> {
+	if (typeof window === 'undefined') {
+		throw new PodBootError('BrowserPod can only boot in the browser.');
+	}
+	if (!crossOriginIsolated) {
+		throw new PodBootError(
+			'This page is not cross-origin isolated, so SharedArrayBuffer is unavailable. ' +
+				'Serve it with Cross-Origin-Opener-Policy: same-origin and ' +
+				'Cross-Origin-Embedder-Policy: require-corp.'
+		);
+	}
+
+	const k = import.meta.env['VITE_BP_APIKEY'] as string | undefined;
+	if (!k) {
+		throw new PodBootError(
+			'No BrowserPod apiKey. Copy .env.example to .env and set VITE_BP_APIKEY.'
+		);
+	}
+
+	// Dynamic so the runtime is never pulled into an SSR or prerender pass.
+	const { BrowserPod } = await import('@leaningtech/browserpod');
+	if (!BrowserPod) throw new PodBootError('The BrowserPod runtime failed to load.');
+
+	return await BrowserPod.boot({ apiKey: k, storageKey });
+}
+
+/** `shutdown` is not in the published types yet (see PR #16). */
+export async function shutdownPod(pod: BrowserPod): Promise<void> {
+	try {
+		await (pod as BrowserPod & { shutdown?: () => Promise<void> }).shutdown?.();
+	} catch (error) {
+		console.error('Failed to shut down pod:', error);
+	}
+}

--- a/examples/showcase/agent-bay/src/lib/pod/fs.ts
+++ b/examples/showcase/agent-bay/src/lib/pod/fs.ts
@@ -1,0 +1,147 @@
+/**
+ * Pod filesystem access. The read and write helpers come from browsercode's
+ * `src/lib/pod/fs.ts`; listing, rename and delete go through a subprocess, since the
+ * pod's file API covers only create, open and mkdir.
+ */
+import type { BinaryFile, BrowserPod, TextFile } from '@leaningtech/browserpod';
+import { failed, failureMessage, run, runScript, stripAnsi } from './run';
+
+/** Clones land in a subdirectory of this. */
+export const POD_HOME = '/home/user';
+
+/** One entry of a listed working tree, relative to the listing root. */
+export type PodEntry = { path: string; dir: boolean };
+
+export function podPath(workdir: string, relative: string): string {
+	return relative ? `${workdir}/${relative}` : workdir;
+}
+
+export async function readPodFile(pod: BrowserPod, absPath: string): Promise<string> {
+	const file = (await pod.openFile(absPath, 'utf-8')) as TextFile;
+	try {
+		const size = await file.getSize();
+		return await file.read(size);
+	} finally {
+		await file.close();
+	}
+}
+
+/** Returns null, without reading, when the file is larger than `maxBytes`. */
+export async function readPodFileWithinLimit(
+	pod: BrowserPod,
+	absPath: string,
+	maxBytes: number
+): Promise<string | null> {
+	const file = (await pod.openFile(absPath, 'utf-8')) as TextFile;
+	try {
+		const size = await file.getSize();
+		if (size > maxBytes) return null;
+		return await file.read(size);
+	} finally {
+		await file.close();
+	}
+}
+
+export async function readPodBinaryFile(
+	pod: BrowserPod,
+	absPath: string
+): Promise<Uint8Array<ArrayBuffer>> {
+	const file = (await pod.openFile(absPath, 'binary')) as BinaryFile;
+	try {
+		const size = await file.getSize();
+		return new Uint8Array(await file.read(size));
+	} finally {
+		await file.close();
+	}
+}
+
+export async function writePodFile(
+	pod: BrowserPod,
+	absPath: string,
+	content: string
+): Promise<void> {
+	await ensureParentDirectory(pod, absPath);
+	const file = (await pod.createFile(absPath, 'utf-8')) as TextFile;
+	try {
+		await file.write(content);
+	} finally {
+		await file.close();
+	}
+}
+
+export async function writePodBinaryFile(
+	pod: BrowserPod,
+	absPath: string,
+	content: ArrayBuffer
+): Promise<void> {
+	await ensureParentDirectory(pod, absPath);
+	const file = (await pod.createFile(absPath, 'binary')) as BinaryFile;
+	try {
+		await file.write(content);
+	} finally {
+		await file.close();
+	}
+}
+
+export async function makeDirectory(pod: BrowserPod, absPath: string): Promise<void> {
+	await pod.createDirectory(absPath, { recursive: true });
+}
+
+async function ensureParentDirectory(pod: BrowserPod, absPath: string): Promise<void> {
+	const parent = absPath.slice(0, absPath.lastIndexOf('/'));
+	if (parent) await pod.createDirectory(parent, { recursive: true });
+}
+
+export async function pathExists(pod: BrowserPod, absPath: string): Promise<boolean> {
+	const result = await run(pod, 'test', ['-e', absPath]);
+	return result.exitCode === 0;
+}
+
+export async function renamePath(pod: BrowserPod, from: string, to: string): Promise<void> {
+	const result = await run(pod, 'mv', ['-f', '--', from, to]);
+	if (failed(result)) throw new Error(failureMessage(result, 'Rename failed'));
+}
+
+export async function removePath(pod: BrowserPod, absPath: string): Promise<void> {
+	const result = await run(pod, 'rm', ['-rf', '--', absPath]);
+	if (failed(result)) throw new Error(failureMessage(result, 'Delete failed'));
+}
+
+const SKIPPED_DIRECTORIES = ['.git', '.jj', 'node_modules'];
+const MAX_TREE_ENTRIES = 20000;
+
+/** Separates the directory pass from the file pass. */
+const LISTING_SPLIT = '__bre_split__';
+
+/**
+ * Two `find` passes rather than one, because the pod's `find` need not be GNU and
+ * `-printf` is the only single pass way to tag each line with its type. The pod's
+ * `node` is a script runner that reads its first argument as a module path, so
+ * `node -e` is not an option either.
+ */
+function listingScript(): string {
+	const prune = SKIPPED_DIRECTORIES.map((name) => `-name ${name}`).join(' -o ');
+	const pass = (test: string) => `find . -mindepth 1 \\( ${prune} \\) -prune -o ${test} -print`;
+	return `${pass('-type d')}; echo '${LISTING_SPLIT}'; ${pass('\\( -type f -o -type l \\)')}`;
+}
+
+/** Every file and directory under `root`, as paths relative to it. */
+export async function listTree(pod: BrowserPod, root: string): Promise<PodEntry[]> {
+	const result = await runScript(pod, listingScript(), { cwd: root });
+	if (failed(result)) throw new Error(failureMessage(result, 'Could not list files'));
+
+	const entries: PodEntry[] = [];
+	let dir = true;
+	for (const line of stripAnsi(result.output).split(/\r?\n/)) {
+		const path = line.trim();
+		if (path === LISTING_SPLIT) {
+			dir = false;
+			continue;
+		}
+		// find prints `./name`; anything else is terminal noise.
+		if (!path.startsWith('./')) continue;
+		if (entries.length >= MAX_TREE_ENTRIES) break;
+		entries.push({ path: path.slice(2), dir });
+	}
+	return entries;
+}

--- a/examples/showcase/agent-bay/src/lib/pod/run.ts
+++ b/examples/showcase/agent-bay/src/lib/pod/run.ts
@@ -1,0 +1,204 @@
+/**
+ * Subprocess plumbing, adapted from browsercode's `IdeSession.runInOutput` with the
+ * terminal UI replaced by a streaming callback.
+ */
+import type { BrowserPod, Terminal } from '@leaningtech/browserpod';
+
+export type LogSink = (chunk: string) => void;
+
+export type RunOptions = {
+	cwd?: string;
+	env?: string[];
+	/** Receives output as it arrives, with the exit marker filtered out. */
+	onData?: LogSink;
+};
+
+export type RunResult = {
+	output: string;
+	/** Exit status, or `-1` when it could not be read. */
+	exitCode: number;
+};
+
+/**
+ * True only for a status we read and that says failed. An unreadable status is not a
+ * failure; callers confirm the effect instead.
+ */
+export function failed(result: RunResult): boolean {
+	return result.exitCode > 0;
+}
+
+/** `pod.run` exposes no exit status, so the wrapper shell prints one. */
+const EXIT_MARKER = '__bre_exit:';
+
+/** How long to keep waiting for the marker after the process has exited. */
+const MARKER_GRACE_MS = 1500;
+
+type Runner = {
+	terminal: Terminal;
+	queue: Promise<unknown>;
+	/** Set for the duration of one run, to receive that run's output. */
+	sink: LogSink | null;
+};
+
+/** One hidden terminal and one queue per pod. */
+const runners = new WeakMap<BrowserPod, Promise<Runner>>();
+
+function runnerFor(pod: BrowserPod): Promise<Runner> {
+	let runner = runners.get(pod);
+	if (!runner) {
+		runner = createRunner(pod);
+		runners.set(pod, runner);
+	}
+	return runner;
+}
+
+async function createRunner(pod: BrowserPod): Promise<Runner> {
+	const decoder = new TextDecoder();
+	const runner: Partial<Runner> = { queue: Promise.resolve(), sink: null };
+	// Wide, so a pty honouring the window size never folds long paths.
+	runner.terminal = await pod.createCustomTerminal({
+		cols: 512,
+		rows: 48,
+		onOutput: (buffer) => runner.sink?.(decoder.decode(copyBytes(buffer), { stream: true }))
+	});
+	return runner as Runner;
+}
+
+/** The pod's chunks are backed by a resizable buffer, which `TextDecoder` rejects. */
+function copyBytes(buffer: ArrayBuffer): Uint8Array<ArrayBuffer> {
+	return new Uint8Array(buffer).slice();
+}
+
+/** Runs a command with quoted arguments, so the shell interprets nothing in them. */
+export function run(
+	pod: BrowserPod,
+	command: string,
+	args: string[],
+	options: RunOptions = {}
+): Promise<RunResult> {
+	return enqueue(pod, [command, ...args].map(shellQuote).join(' '), options);
+}
+
+/** Runs a bash line as written, for pipes and globs. Quoting is the caller's job. */
+export function runScript(
+	pod: BrowserPod,
+	script: string,
+	options: RunOptions = {}
+): Promise<RunResult> {
+	return enqueue(pod, script, options);
+}
+
+/** Runs are queued per pod, so callers never need to coordinate. */
+async function enqueue(pod: BrowserPod, line: string, options: RunOptions): Promise<RunResult> {
+	const runner = await runnerFor(pod);
+	const task = () => execute(pod, runner, line, options);
+	// `.then(task, task)` keeps the queue alive after a failed run.
+	const result = runner.queue.then(task, task);
+	runner.queue = result.catch(() => undefined);
+	return result;
+}
+
+async function execute(
+	pod: BrowserPod,
+	runner: Runner,
+	line: string,
+	{ cwd, env, onData }: RunOptions
+): Promise<RunResult> {
+	// The leading newline keeps the marker on its own line whatever the command wrote.
+	const script = `${line}; printf '\\n${EXIT_MARKER}%d\\n' "$?"`;
+
+	let raw = '';
+	const filter = createMarkerFilter(EXIT_MARKER, onData);
+	runner.sink = (chunk) => {
+		raw += chunk;
+		filter.push(chunk);
+	};
+	try {
+		await pod.run('bash', ['-c', script], {
+			terminal: runner.terminal,
+			echo: false,
+			...(cwd ? { cwd } : {}),
+			...(env ? { env } : {})
+		});
+		// `run` resolves on process exit with output still in flight, so wait for it.
+		for (let waited = 0; waited < MARKER_GRACE_MS && !raw.includes(EXIT_MARKER); waited += 25) {
+			await new Promise((resolve) => setTimeout(resolve, 25));
+		}
+	} finally {
+		runner.sink = null;
+		filter.flush();
+	}
+
+	const at = raw.lastIndexOf(EXIT_MARKER);
+	if (at < 0) return { output: raw, exitCode: -1 };
+	const parsed = Number.parseInt(raw.slice(at + EXIT_MARKER.length).trim(), 10);
+	return {
+		output: raw.slice(0, at).replace(/\r?\n$/, ''),
+		exitCode: Number.isFinite(parsed) ? parsed : -1
+	};
+}
+
+/** Forwards a stream to `sink`, holding back the marker even when a chunk splits it. */
+function createMarkerFilter(marker: string, sink?: LogSink) {
+	let held = '';
+	let finished = false;
+
+	const emit = (text: string) => {
+		if (text) sink?.(text);
+	};
+
+	return {
+		push(chunk: string) {
+			if (finished || !sink) return;
+			held += chunk;
+			const at = held.indexOf(marker);
+			if (at >= 0) {
+				emit(held.slice(0, at).replace(/\r?\n$/, ''));
+				held = '';
+				finished = true;
+				return;
+			}
+			const keep = partialMarkerLength(held, marker);
+			emit(held.slice(0, held.length - keep));
+			held = keep ? held.slice(held.length - keep) : '';
+		},
+		flush() {
+			if (finished || !sink) return;
+			emit(held);
+			held = '';
+		}
+	};
+}
+
+/** Length of the longest suffix of `text` that is also a prefix of `marker`. */
+function partialMarkerLength(text: string, marker: string): number {
+	for (let n = Math.min(text.length, marker.length - 1); n > 0; n--) {
+		if (text.endsWith(marker.slice(0, n))) return n;
+	}
+	return 0;
+}
+
+export function shellQuote(value: string): string {
+	return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+/** The line worth showing when a command fails: its last non-empty one. */
+export function failureMessage(result: RunResult, fallback: string): string {
+	const lines = result.output
+		.split(/\r?\n/)
+		.map((line) => stripAnsi(line).trim())
+		.filter(Boolean);
+	return lines.at(-1) ?? `${fallback} (exit ${result.exitCode})`;
+}
+
+// CSI and OSC sequences, built with fromCharCode to keep this file plain ASCII.
+const ESC = String.fromCharCode(27);
+const BEL = String.fromCharCode(7);
+const ANSI_PATTERN = new RegExp(
+	ESC + '\\[[0-9;?]*[ -/]*[@-~]|' + ESC + '\\][^' + BEL + ESC + ']*(?:' + BEL + '|' + ESC + '\\\\)?',
+	'g'
+);
+
+export function stripAnsi(value: string): string {
+	return value.replace(ANSI_PATTERN, '');
+}

--- a/examples/showcase/agent-bay/src/routes/+page.svelte
+++ b/examples/showcase/agent-bay/src/routes/+page.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+	import { bootPod } from '$lib/pod/boot';
+	import { runMission, type MissionReport } from '$lib/mission/runner';
+	import { EXAMPLE_MISSIONS } from '$lib/mission/examples';
+	import type { Mission } from '$lib/mission/types';
+
+	let pod: import('@leaningtech/browserpod').BrowserPod | null = null;
+	let bootError = '';
+	let booting = false;
+	let running = false;
+	let report: MissionReport | null = null;
+	let consoleLines = '';
+	let portalUrl = '';
+	let missionText = JSON.stringify(EXAMPLE_MISSIONS[0], null, 2);
+	let parseError = '';
+
+	async function ensurePod() {
+		if (pod) return pod;
+		booting = true;
+		bootError = '';
+		try {
+			pod = await bootPod();
+			pod.onPortal(({ url }) => {
+				portalUrl = url;
+			});
+		} catch (err) {
+			bootError = err instanceof Error ? err.message : String(err);
+		} finally {
+			booting = false;
+		}
+		return pod;
+	}
+
+	function parseMission(text: string): Mission | null {
+		try {
+			const parsed = JSON.parse(text);
+			if (!parsed || typeof parsed !== 'object' || !parsed.name || !parsed.clone?.url || !Array.isArray(parsed.steps)) {
+				parseError = 'Mission needs a name, a clone.url and a non-empty steps array.';
+				return null;
+			}
+			parseError = '';
+			return parsed as Mission;
+		} catch (err) {
+			parseError = err instanceof Error ? err.message : String(err);
+			return null;
+		}
+	}
+
+	function appendConsole(line: string) {
+		consoleLines += line + '\n';
+	}
+
+	async function run() {
+		const parsed = parseMission(missionText);
+		if (!parsed) return;
+		const p = await ensurePod();
+		if (!p) return;
+
+		running = true;
+		report = null;
+		consoleLines = '';
+		appendConsole('▶ mission: ' + parsed.name);
+		appendConsole('  clone ' + parsed.clone.url + (parsed.clone.ref ? ` (${parsed.clone.ref})` : ''));
+		appendConsole('  locks: ' + (parsed.locks.join(', ') || '(none — writes blocked)'));
+
+		try {
+			const r = await runMission(p, parsed);
+			report = r;
+			for (const s of r.steps) {
+				appendConsole(`  ${s.status.toUpperCase()} ${s.label} (exit ${s.exitCode})`);
+				if (s.blockedReason) appendConsole(`    blocked: ${s.blockedReason}`);
+				else if (s.output.trim()) appendConsole('    ' + s.output.trim().split('\n').slice(-3).join('\n    '));
+			}
+			appendConsole(
+				'verdict: ' +
+					(r.cloneFailed ?? (r.steps.some((s) => s.status === 'failed') ? 'failed' : 'done'))
+			);
+		} catch (err) {
+			appendConsole('run error: ' + (err instanceof Error ? err.message : String(err)));
+		} finally {
+			running = false;
+		}
+	}
+
+	function useExample(i: number) {
+		missionText = JSON.stringify(EXAMPLE_MISSIONS[i], null, 2);
+		parseError = '';
+	}
+</script>
+
+<svelte:head>
+	<title>Agent Bay — gated agent jobs in the browser</title>
+</svelte:head>
+
+<main class="min-h-screen bg-zinc-950 text-zinc-200 font-mono p-6">
+	<header class="flex items-center justify-between mb-6">
+		<div>
+			<h1 class="text-2xl font-bold text-zinc-50">Agent Bay</h1>
+			<p class="text-zinc-500 text-sm">
+				A mission-driven agent loop in a BrowserPod sandbox. Every write and exec goes
+				through the gate; anything outside the locked lanes is refused.
+			</p>
+		</div>
+		<div class="flex items-center gap-3">
+			<span
+				class="text-xs px-2 py-1 rounded {crossOriginIsolated ? 'bg-emerald-900/50 text-emerald-300' : 'bg-red-900/50 text-red-300'}"
+			>
+				{crossOriginIsolated ? 'cross-origin isolated' : 'NOT isolated — SharedArrayBuffer unavailable'}
+			</span>
+			<button
+				class="px-3 py-1 rounded bg-indigo-600 hover:bg-indigo-500 disabled:opacity-40 disabled:cursor-not-allowed text-sm"
+				disabled={running || !crossOriginIsolated}
+				onclick={run}
+			>
+				{running ? 'running…' : 'Run mission'}
+			</button>
+		</div>
+	</header>
+
+	<div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+		<section class="bg-zinc-900 border border-zinc-800 rounded-lg p-4">
+			<div class="flex items-center justify-between mb-2">
+				<h2 class="text-sm text-zinc-400">mission.json</h2>
+				<div class="flex gap-1">
+					{#each EXAMPLE_MISSIONS as _, i}
+						<button class="text-xs px-2 py-0.5 rounded bg-zinc-800 hover:bg-zinc-700" onclick={() => useExample(i)}>
+							example {i + 1}
+						</button>
+					{/each}
+				</div>
+			</div>
+			<textarea
+				bind:value={missionText}
+				class="w-full h-96 bg-black/50 border border-zinc-800 rounded text-xs p-3 text-emerald-300 focus:outline-none focus:border-indigo-500"
+				spellcheck="false"
+			></textarea>
+			{#if parseError}<p class="text-red-400 text-xs mt-2">{parseError}</p>{/if}
+		</section>
+
+		<section class="bg-zinc-900 border border-zinc-800 rounded-lg p-4 flex flex-col">
+			<div class="flex items-center justify-between mb-2">
+				<h2 class="text-sm text-zinc-400">console</h2>
+				{#if portalUrl}
+					<a href={portalUrl} target="_blank" rel="noreferrer" class="text-xs text-indigo-400 hover:underline">
+						portal: {portalUrl}
+					</a>
+				{/if}
+			</div>
+			<pre
+				class="flex-1 h-96 overflow-auto bg-black/50 border border-zinc-800 rounded-lg p-3 text-xs text-zinc-300 whitespace-pre-wrap"
+			>{consoleLines || (running ? 'bootstrapping pod…' : bootError || 'idle — write a mission, then run')}</pre>
+		</section>
+	</div>
+
+	{#if report}
+		<section class="mt-4 bg-zinc-900 border border-zinc-800 rounded-lg p-4">
+			<h2 class="text-sm text-zinc-400 mb-2">verdicts</h2>
+			<table class="w-full text-xs">
+				<thead>
+					<tr class="text-zinc-500 text-left">
+						<th class="py-1">step</th>
+						<th>status</th>
+						<th>exit</th>
+						<th class="w-1/2">output (tail)</th>
+					</tr>
+				</thead>
+				<tbody>
+					{#each report.steps as s (s.label + s.status)}
+						<tr class="border-t border-zinc-800">
+							<td class="py-1 pr-2">{s.label}</td>
+							<td class="py-1 pr-2">
+								<span
+									class="px-1.5 rounded text-xs {s.status === 'ok' ? 'bg-emerald-900/50 text-emerald-300' : s.status === 'blocked' ? 'bg-amber-900/50 text-amber-300' : 'bg-red-900/50 text-red-300'}"
+								>
+									{s.status}
+								</span>
+							</td>
+							<td class="py-1 pr-2">{s.exitCode}</td>
+							<td class="py-1 text-zinc-400 whitespace-pre-wrap">
+								{s.blockedReason ?? s.output.trim().split('\n').slice(-3).join('\n')}
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+			<p class="text-xs text-zinc-500 mt-2">
+				verdict log written to <code class="text-emerald-400">/repo/{report.verdictPath}</code> in the sandbox
+			</p>
+		</section>
+	{/if}
+
+	{#if bootError}
+		<p class="mt-3 text-xs text-red-400">{bootError}</p>
+	{/if}
+</main>

--- a/examples/showcase/agent-bay/static/_headers
+++ b/examples/showcase/agent-bay/static/_headers
@@ -1,0 +1,5 @@
+# BrowserPod needs SharedArrayBuffer, which requires a cross-origin-isolated document.
+/*
+  Cross-Origin-Opener-Policy: same-origin
+  Cross-Origin-Embedder-Policy: require-corp
+  Cross-Origin-Resource-Policy: cross-origin

--- a/examples/showcase/agent-bay/svelte.config.js
+++ b/examples/showcase/agent-bay/svelte.config.js
@@ -1,0 +1,15 @@
+import adapter from '@sveltejs/adapter-static';
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+	kit: {
+		adapter: adapter({
+			pages: 'dist',
+			assets: 'dist',
+			fallback: '200.html'
+		}),
+		prerender: { handleUnseenRoutes: 'ignore' }
+	}
+};
+
+export default config;

--- a/examples/showcase/agent-bay/tsconfig.json
+++ b/examples/showcase/agent-bay/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"extends": "./.svelte-kit/tsconfig.json",
+	"compilerOptions": {
+		"allowJs": true,
+		"checkJs": true,
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"resolveJsonModule": true,
+		"skipLibCheck": true,
+		"sourceMap": true,
+		"strict": true,
+		"moduleResolution": "bundler"
+	},
+	"exclude": ["node_modules/**", "dist/**"]
+}

--- a/examples/showcase/agent-bay/vite.config.ts
+++ b/examples/showcase/agent-bay/vite.config.ts
@@ -1,0 +1,40 @@
+import tailwindcss from '@tailwindcss/vite';
+import { sveltekit } from '@sveltejs/kit/vite';
+import { defineConfig, type Plugin } from 'vite';
+import type { ServerResponse } from 'node:http';
+
+/** BrowserPod needs SharedArrayBuffer, which requires a cross-origin isolated page. */
+const ISOLATION_HEADERS = {
+	'Cross-Origin-Opener-Policy': 'same-origin',
+	'Cross-Origin-Embedder-Policy': 'require-corp',
+	'Cross-Origin-Resource-Policy': 'cross-origin'
+};
+
+function crossOriginIsolation(): Plugin {
+	const apply = (response: ServerResponse) => {
+		for (const [header, value] of Object.entries(ISOLATION_HEADERS)) {
+			response.setHeader(header, value);
+		}
+	};
+	return {
+		name: 'agent-bay:cross-origin-isolation',
+		configureServer(server) {
+			server.middlewares.use((_request, response, next) => {
+				apply(response);
+				next();
+			});
+		},
+		configurePreviewServer(server) {
+			server.middlewares.use((_request, response, next) => {
+				apply(response);
+				next();
+			});
+		}
+	};
+}
+
+export default defineConfig({
+	plugins: [crossOriginIsolation(), tailwindcss(), sveltekit()],
+	server: { headers: ISOLATION_HEADERS },
+	preview: { headers: ISOLATION_HEADERS }
+});


### PR DESCRIPTION
## What

A new showcase example: **Agent Bay** — a mission-driven agent loop inside a BrowserPod sandbox.

The README lists *"Agentic coding and AI-generated code execution: run untrusted code generated by AI agents in a contained environment"* as a core use case, but none of the current examples ship it — bramble clones/edits, the others boot servers. Agent Bay demonstrates the missing lane: an agent that *works* on a repo, with a deterministic capability boundary instead of an unbounded shell.

## How it works

- **mission.json** — the task contract: a repo to clone, the lanes the agent may write to, and a list of bash steps.
- **The gate** — a ~40-line allowlist script installed into the pod and run before every mutation (`node gate.js write <json>`). Writes and mkdirs outside the mission's declared lanes are refused; shell redirections (`>`, `>>`) are checked against the lanes too; path escapes (`..`, absolute paths) are rejected. `.git`/`.jj` are always locked out.
- **Runner** — clones the repo (shallow, fresh each run), runs steps in order through the gate, stops at the first failure, writes a verdict log into the sandbox.
- **UI** — mission editor with two included examples, streaming console, portal link when a server comes up, verdict table.

## Design note

The gate is deliberately boring: model output is untrusted input, so proposed actions execute only behind a cheap, explicit allowlist — denied by construction, not by review. Same principle as a token gate. It keeps the sandbox the primary boundary while giving agent authors a way to scope what a mission may touch.

## House style

Reuses bramble's pod plumbing (`run.ts`, `fs.ts`) and its COOP/COEP cross-origin-isolation setup verbatim; same `npm run dev` / `npm run build` / `npm run check` flow — svelte-check is clean and the static build passes.
